### PR TITLE
Modified LauncherInterface 

### DIFF
--- a/src/main/java/ca/warp7/frc2022/auton/commands/AutoFeedCommand.java
+++ b/src/main/java/ca/warp7/frc2022/auton/commands/AutoFeedCommand.java
@@ -27,7 +27,7 @@ public class AutoFeedCommand extends CommandBase {
         boolean highBeamBreak = Elevator.getHighBeamBreak();
         boolean isShooting = shootingSupplier.getAsBoolean();
 
-        if ((isShooting && launcher.isTargetReached(0.015)) || (lowBeamBreak && !highBeamBreak)) {
+        if ((isShooting && launcher.isTargetReached()) || (lowBeamBreak && !highBeamBreak)) {
             elevator.setSpeed(kElevatorSpeed);
             // intake.setSpeed(kIntakeSpeed);
         } else {

--- a/src/main/java/ca/warp7/frc2022/subsystems/Launcher.java
+++ b/src/main/java/ca/warp7/frc2022/subsystems/Launcher.java
@@ -63,13 +63,13 @@ public class Launcher  implements LauncherInterface{
         SmartDashboard.putNumber("Target RPS", targetRPS);
         SmartDashboard.putNumber("Current RPS", currentRPS);
         SmartDashboard.putBoolean("Is launcher running", runLauncher);
-        SmartDashboard.putBoolean("Is RPS target reached", this.isTargetReached(0.1));
+        SmartDashboard.putBoolean("Is RPS target reached", this.isTargetReached());
     }
 
     //Bad temp documentation note: Epsilon is the allowed decemal error since doubles and floats subtract weird.
     @Override
-    public boolean isTargetReached(double epsilon) {
-        return Util.epsilonEquals(getPercentError(), 0.0, epsilon);
+    public boolean isTargetReached() {
+        return Util.epsilonEquals(getPercentError(), 0.0, 0.001);
     }
 
     @Override

--- a/src/main/java/ca/warp7/frc2022/subsystems/Launcher.java
+++ b/src/main/java/ca/warp7/frc2022/subsystems/Launcher.java
@@ -72,7 +72,7 @@ public class Launcher  implements LauncherInterface{
     //Bad temp documentation note: Epsilon is the allowed decemal error since doubles and floats subtract weird.
     @Override
     public boolean isTargetReached() {
-        return Util.epsilonEquals(getPercentError(), 0.0, 0.001);
+        return Util.epsilonEquals(getPercentError(), 0.0, 0.1);
     }
 
     @Override

--- a/src/main/java/ca/warp7/frc2022/subsystems/LauncherInterface.java
+++ b/src/main/java/ca/warp7/frc2022/subsystems/LauncherInterface.java
@@ -4,7 +4,7 @@ import edu.wpi.first.wpilibj2.command.Subsystem;
 
 public interface LauncherInterface extends Subsystem {
     //Bad temp documentation note: Epsilon is the allowed decemal error since doubles and floats subtract weird.
-    public boolean isTargetReached(double epsilon);
+    public boolean isTargetReached();
 
     public void setRunLauncher(boolean newRunLauncher);
 

--- a/src/main/java/ca/warp7/frc2022/subsystems/LazyLauncher.java
+++ b/src/main/java/ca/warp7/frc2022/subsystems/LazyLauncher.java
@@ -17,7 +17,7 @@ public class LazyLauncher implements LauncherInterface {
 
     
     @Override
-    public boolean isTargetReached(double epsilon) {
+    public boolean isTargetReached() {
         return(true);
     }
 


### PR DESCRIPTION
An epsilon value is not needed to call isTargetReached() anymore.